### PR TITLE
Add API service and auth service with mock functionality

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,39 @@
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// Request Interceptor: Add Authorization header
+api.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('nexus_token') : null;
+    if (token && config.headers) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  }
+);
+
+// Response Interceptor: Handle common errors
+api.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      // Logic for handling unauthorized access (e.g., redirect to login)
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('nexus_token');
+        // window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,54 @@
+import api from './api';
+import { User } from '@/types';
+
+// Mock data for development
+const MOCK_USER: User = {
+  id: '1',
+  name: 'John Doe',
+  email: 'john.doe@example.com',
+  role: 'Sales Executive',
+  avatar: 'https://i.pravatar.cc/150?u=1',
+};
+
+export const authService = {
+  async login(email: string, password: string): Promise<{ user: User; token: string }> {
+    try {
+      // Real API call
+      // const response = await api.post('/auth/login', { email, password });
+      // return response.data;
+
+      // Mock fallback
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            user: MOCK_USER,
+            token: 'mock-jwt-token-12345',
+          });
+        }, 1000);
+      });
+    } catch (error) {
+      throw error;
+    }
+  },
+
+  async logout(): Promise<void> {
+    // const response = await api.post('/auth/logout');
+    localStorage.removeItem('nexus_token');
+  },
+
+  async getCurrentUser(): Promise<User> {
+    try {
+      // const response = await api.get('/auth/me');
+      // return response.data;
+
+      // Mock fallback
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(MOCK_USER);
+        }, 500);
+      });
+    } catch (error) {
+      throw error;
+    }
+  },
+};


### PR DESCRIPTION
- Implement Axios-based `api` service with interceptors for authorization and error handling.
- Create `authService` with mock methods for login, logout, and fetching current user.