### PR TITLE
feat: Implement core application pages for contracts, clients, proposals, and opportunities, and add comprehensive project documentation.

### DIFF
--- a/src/app/(main)/clients/[id]/page.tsx
+++ b/src/app/(main)/clients/[id]/page.tsx
@@ -11,7 +11,7 @@ import {
     HistoryOutlined,
     EditOutlined
 } from '@ant-design/icons';
-import { Client, Contact, Opportunity } from '@/types';
+import { Client, Contact, Opportunity, UserRole } from '@/types';
 import { OpportunityStage } from '@/types/enums';
 import opportunityService from '@/services/opportunityService';
 import clientService from '@/services/clientService';
@@ -19,6 +19,7 @@ import contactService from '@/services/contactService';
 import PageHeader from '@/components/shared/PageHeader';
 import ContactModal from '@/components/clients/ContactModal';
 import OpportunityModal from '@/components/opportunities/OpportunityModal';
+import { useHasRole } from '@/hooks/useHasRole';
 
 const { Text } = Typography;
 
@@ -31,6 +32,7 @@ export default function ClientDetailPage() {
     const [loading, setLoading] = useState(true);
     const [isContactModalOpen, setIsContactModalOpen] = useState(false);
     const [isOpportunityModalOpen, setIsOpportunityModalOpen] = useState(false);
+    const { hasRole: canCreate } = useHasRole([UserRole.ADMIN, UserRole.SALES_MANAGER, UserRole.BUSINESS_DEVELOPMENT_MANAGER]);
 
     const fetchClientAndContacts = async () => {
         if (!id) return;
@@ -88,8 +90,8 @@ export default function ClientDetailPage() {
 
     const extra = (
         <Space size="middle">
-            <Button icon={<EditOutlined />}>Edit Client</Button>
-            <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsOpportunityModalOpen(true)}>New Opportunity</Button>
+            <Button icon={<EditOutlined />} disabled={!canCreate}>Edit Client</Button>
+            <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsOpportunityModalOpen(true)} disabled={!canCreate}>New Opportunity</Button>
         </Space>
     );
 

--- a/src/app/(main)/clients/page.tsx
+++ b/src/app/(main)/clients/page.tsx
@@ -4,16 +4,18 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Button, Input, Select, Space, Tag } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { Client } from '@/types';
+import { Client, UserRole } from '@/types';
 import { useClients, useClientActions } from '@/providers/clientProvider';
 import DataTable from '@/components/shared/DataTable';
 import PageHeader from '@/components/shared/PageHeader';
 import ClientModal from '@/components/clients/ClientModal';
+import { useHasRole } from '@/hooks/useHasRole';
 
 export default function ClientsPage() {
     const { clients, isPending, filters, totalCount } = useClients();
     const { fetchClients, setFilters } = useClientActions();
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const { hasRole: canCreate } = useHasRole([UserRole.ADMIN, UserRole.SALES_MANAGER, UserRole.BUSINESS_DEVELOPMENT_MANAGER]);
 
     useEffect(() => {
         fetchClients();
@@ -103,7 +105,7 @@ export default function ClientsPage() {
                 style={{ width: 120 }}
                 value={filters.isActive}
             />
-            <Button type="primary" onClick={() => setIsModalOpen(true)}>New Client</Button>
+            <Button type="primary" onClick={() => setIsModalOpen(true)} disabled={!canCreate}>New Client</Button>
         </Space>
     );
 

--- a/src/app/(main)/contracts/page.tsx
+++ b/src/app/(main)/contracts/page.tsx
@@ -9,10 +9,13 @@ import { useContracts, useContractActions } from '@/providers/contractProvider';
 import DataTable from '@/components/shared/DataTable';
 import PageHeader from '@/components/shared/PageHeader';
 import StatusBadge from '@/components/shared/StatusBadge';
+import { useHasRole } from '@/hooks/useHasRole';
+import { UserRole } from '@/types';
 
 export default function ContractsPage() {
     const { contracts, isPending, filters, totalCount } = useContracts();
     const { fetchContracts, setFilters } = useContractActions();
+    const { hasRole: canCreate } = useHasRole([UserRole.ADMIN, UserRole.SALES_MANAGER, UserRole.BUSINESS_DEVELOPMENT_MANAGER]);
 
     useEffect(() => {
         fetchContracts();
@@ -89,7 +92,7 @@ export default function ContractsPage() {
                 style={{ width: 160 }}
                 value={filters.status}
             />
-            <Button type="primary">New Contract</Button>
+            <Button type="primary" disabled={!canCreate}>New Contract</Button>
         </Space>
     );
 

--- a/src/app/(main)/opportunities/page.tsx
+++ b/src/app/(main)/opportunities/page.tsx
@@ -10,12 +10,18 @@ import DataTable from '@/components/shared/DataTable';
 import PageHeader from '@/components/shared/PageHeader';
 import OpportunityModal from '@/components/opportunities/OpportunityModal';
 import dashboardService from '@/services/dashboardService';
+import RoleGate from '@/components/shared/RoleGate';
+import { useHasRole } from '@/hooks/useHasRole';
+import { UserRole } from '@/types';
 
 export default function OpportunitiesPage() {
     const { opportunities, isPending, filters, totalCount } = useOpportunities();
-    const { fetchOpportunities, setFilters, updateStage, assignOpportunity } = useOpportunityActions();
+    const { fetchOpportunities, fetchMyOpportunities, setFilters, updateStage, assignOpportunity } = useOpportunityActions();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [salesReps, setSalesReps] = useState<Array<{ userId: string; userName: string }>>([]);
+    const { hasRole: canAssign } = useHasRole([UserRole.ADMIN, UserRole.SALES_MANAGER]);
+    const { hasRole: canCreate } = useHasRole([UserRole.ADMIN, UserRole.SALES_MANAGER, UserRole.BUSINESS_DEVELOPMENT_MANAGER]);
+    const { hasRole: isSalesRep } = useHasRole([UserRole.SALES_REP]);
 
     useEffect(() => {
         const loadSalesReps = async () => {
@@ -50,8 +56,12 @@ export default function OpportunitiesPage() {
     };
 
     useEffect(() => {
-        fetchOpportunities();
-    }, [filters, fetchOpportunities]);
+        if (isSalesRep) {
+            fetchMyOpportunities(filters);
+        } else {
+            fetchOpportunities();
+        }
+    }, [filters, fetchOpportunities, fetchMyOpportunities, isSalesRep]);
 
     const handleSearch = (value: string) => {
         setFilters({ ...filters, searchTerm: value, pageNumber: 1 });
@@ -90,20 +100,24 @@ export default function OpportunitiesPage() {
             dataIndex: 'stage',
             key: 'stage',
             render: (stage: OpportunityStage, record) => (
-                <Select
-                    value={stage}
-                    onChange={(value) => handleUpdateStage(record.id, value)}
-                    style={{ width: 140 }}
-                    size="small"
-                    options={[
-                        { value: 1, label: 'Lead' },
-                        { value: 2, label: 'Qualified' },
-                        { value: 3, label: 'Proposal' },
-                        { value: 4, label: 'Negotiation' },
-                        { value: 5, label: 'Closed Won' },
-                        { value: 6, label: 'Closed Lost' }
-                    ]}
-                />
+                canCreate ? (
+                    <Select
+                        value={stage}
+                        onChange={(value) => handleUpdateStage(record.id, value)}
+                        style={{ width: 140 }}
+                        size="small"
+                        options={[
+                            { value: 1, label: 'Lead' },
+                            { value: 2, label: 'Qualified' },
+                            { value: 3, label: 'Proposal' },
+                            { value: 4, label: 'Negotiation' },
+                            { value: 5, label: 'Closed Won' },
+                            { value: 6, label: 'Closed Lost' }
+                        ]}
+                    />
+                ) : (
+                    <span>{stage}</span>
+                )
             ),
         },
         {
@@ -122,14 +136,14 @@ export default function OpportunitiesPage() {
             dataIndex: 'ownerName',
             key: 'ownerName',
         },
-        {
+        ...(canAssign ? [{
             title: 'Assign',
-            key: 'assign',
+            key: 'assign' as const,
             width: 180,
-            render: (_, record) => (
+            render: (_: any, record: Opportunity) => (
                 <Select
                     value={record.ownerId || undefined}
-                    onChange={(value) => handleAssign(record.id, value)}
+                    onChange={(value: string) => handleAssign(record.id, value)}
                     placeholder="Assign rep"
                     style={{ width: 160 }}
                     size="small"
@@ -138,7 +152,7 @@ export default function OpportunitiesPage() {
                     options={salesReps.map(rep => ({ value: rep.userId, label: rep.userName }))}
                 />
             ),
-        },
+        }] : []),
     ];
 
     const extra = (
@@ -173,7 +187,7 @@ export default function OpportunitiesPage() {
                 style={{ width: 120 }}
                 value={filters.isActive}
             />
-            <Button type="primary" onClick={() => setIsModalOpen(true)}>New Opportunity</Button>
+            <Button type="primary" onClick={() => setIsModalOpen(true)} disabled={!canCreate}>New Opportunity</Button>
         </Space>
     );
 

--- a/src/app/(main)/proposals/page.tsx
+++ b/src/app/(main)/proposals/page.tsx
@@ -9,10 +9,13 @@ import { useProposals, useProposalActions } from '@/providers/proposalProvider';
 import DataTable from '@/components/shared/DataTable';
 import PageHeader from '@/components/shared/PageHeader';
 import StatusBadge from '@/components/shared/StatusBadge';
+import { useHasRole } from '@/hooks/useHasRole';
+import { UserRole } from '@/types';
 
 export default function ProposalsPage() {
     const { proposals, isPending, filters, totalCount } = useProposals();
     const { fetchProposals, setFilters } = useProposalActions();
+    const { hasRole: canCreate } = useHasRole([UserRole.ADMIN, UserRole.SALES_MANAGER, UserRole.BUSINESS_DEVELOPMENT_MANAGER]);
 
     useEffect(() => {
         fetchProposals();
@@ -90,7 +93,7 @@ export default function ProposalsPage() {
                 style={{ width: 160 }}
                 value={filters.status}
             />
-            <Button type="primary">New Proposal</Button>
+            <Button type="primary" disabled={!canCreate}>New Proposal</Button>
         </Space>
     );
 

--- a/src/components/shared/RoleGate.tsx
+++ b/src/components/shared/RoleGate.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+import { UserRole } from '@/types';
+import { useHasRole } from '@/hooks/useHasRole';
+
+interface RoleGateProps {
+  /** Roles that are allowed to see the children */
+  readonly roles: (UserRole | string)[];
+  /** Content rendered when the user has access */
+  readonly children: React.ReactNode;
+  /** Optional fallback rendered when access is denied (defaults to nothing) */
+  readonly fallback?: React.ReactNode;
+}
+
+/**
+ * Conditionally renders children based on the current user's role.
+ * If the user does not hold any of the specified roles, renders `fallback` (or nothing).
+ */
+export default function RoleGate({ roles, children, fallback = null }: RoleGateProps) {
+  const { hasRole, isLoading } = useHasRole(roles);
+
+  if (isLoading) return null;
+  if (!hasRole) return <>{fallback}</>;
+  return <>{children}</>;
+}


### PR DESCRIPTION
This pull request introduces role-based access control to various UI actions across the client, contract, opportunity, and proposal management pages. By leveraging a new `useHasRole` hook and a reusable `RoleGate` component, it ensures that only users with appropriate roles can perform sensitive actions such as creating, editing, or assigning entities. The most important changes are summarized below.

**Role-based UI permissions and controls:**

* Added the `useHasRole` hook throughout the app to check for user roles (such as `ADMIN`, `SALES_MANAGER`, and `BUSINESS_DEVELOPMENT_MANAGER`) before enabling or displaying action buttons like "New Client", "Edit Client", "New Contract", "New Opportunity", and "New Proposal". These buttons are now disabled for users lacking the required roles. ([src/app/(main)/clients/[id]/page.tsxL14-R22](diffhunk://#diff-4a57b2472b87357231b41df5bbfc6169966523db4a03abee0ba1288c838937caL14-R22), [src/app/(main)/clients/[id]/page.tsxR35](diffhunk://#diff-4a57b2472b87357231b41df5bbfc6169966523db4a03abee0ba1288c838937caR35), [src/app/(main)/clients/[id]/page.tsxL91-R94](diffhunk://#diff-4a57b2472b87357231b41df5bbfc6169966523db4a03abee0ba1288c838937caL91-R94), [[1]](diffhunk://#diff-31f9626d7e41f6e4347a7ec621c23fc75d50166a790a7a4f8677b47131c90b2cL7-R18) [[2]](diffhunk://#diff-31f9626d7e41f6e4347a7ec621c23fc75d50166a790a7a4f8677b47131c90b2cL106-R108) [[3]](diffhunk://#diff-6a2256eba66d858b4b600b8b2fc314c4982f3131452425cdb538feaea1cd8bc0R12-R18) [[4]](diffhunk://#diff-6a2256eba66d858b4b600b8b2fc314c4982f3131452425cdb538feaea1cd8bc0L92-R95) [[5]](diffhunk://#diff-54d4efcdd478d02b21791bbf11c74ff14e1e170bb5f1db63493fd4cc427b4c1aR13-R24) [[6]](diffhunk://#diff-54d4efcdd478d02b21791bbf11c74ff14e1e170bb5f1db63493fd4cc427b4c1aL176-R190) [[7]](diffhunk://#diff-62d9a7e04c66e52e5a3dbadb41e32fa0d8542ef4c04f579aac8133c9349f3246R12-R18) [[8]](diffhunk://#diff-62d9a7e04c66e52e5a3dbadb41e32fa0d8542ef4c04f579aac8133c9349f3246L93-R96)

* In the opportunities page, assignment of opportunities and stage changes are now only available to users with the appropriate roles (`canAssign` and `canCreate`), and the UI reflects these permissions by conditionally rendering controls or read-only text. [[1]](diffhunk://#diff-54d4efcdd478d02b21791bbf11c74ff14e1e170bb5f1db63493fd4cc427b4c1aR103) [[2]](diffhunk://#diff-54d4efcdd478d02b21791bbf11c74ff14e1e170bb5f1db63493fd4cc427b4c1aR118-R120) [[3]](diffhunk://#diff-54d4efcdd478d02b21791bbf11c74ff14e1e170bb5f1db63493fd4cc427b4c1aL125-R146) [[4]](diffhunk://#diff-54d4efcdd478d02b21791bbf11c74ff14e1e170bb5f1db63493fd4cc427b4c1aL141-R155)

**Conditional data fetching based on user role:**

* Updated the opportunities page to fetch either all opportunities or only the current user's opportunities, depending on whether the user is a sales rep, further enforcing role-based data access.

**New reusable component:**

* Added a new `RoleGate` component that conditionally renders its children based on the current user's roles, providing a reusable pattern for role-based UI gating.